### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,8 +22,8 @@ jobs:
         id: vars
         run: |
           which pulumi
-          echo ::set-output name=installed-version::$(pulumi version)
-          echo ::set-output name=expected-version::v$(curl -sS https://www.pulumi.com/latest-version)
+          echo installed-version=$(pulumi version) >> "$GITHUB_OUTPUT"
+          echo expected-version=v$(curl -sS https://www.pulumi.com/latest-version) >> "$GITHUB_OUTPUT"
       - name: Error if incorrect version found
         if: steps.vars.outputs.expected-version != steps.vars.outputs.installed-version
         run: |


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter