### PR TITLE
update CI job to use the main branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,17 +3,17 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   build:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@main
       - name: Add Pulumi Homebrew Tap
         run: brew tap pulumi/tap .
       - name: Try to Install Pulumi


### PR DESCRIPTION
Update the CI jobs to use the main branch instead of the master branch.  This should be merged right after the rename happens.  This repo is not very active, so it's probably not worth doing a two step approach of first adding the main branch renaming and then removing the `master` reference from the workflow files.