### PR TITLE
Add `master` back as a fallback branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - master
   pull_request:
     branches:
       - main

--- a/.github/workflows/synchronize-with-main.yml
+++ b/.github/workflows/synchronize-with-main.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+        with:
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+      - name: Push to `master`
+        run: |
+          git push origin HEAD:main

--- a/.github/workflows/synchronize-with-main.yml
+++ b/.github/workflows/synchronize-with-main.yml
@@ -18,4 +18,4 @@ jobs:
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
       - name: Push to `master`
         run: |
-          git push origin HEAD:main
+          git push origin HEAD:master


### PR DESCRIPTION
Homebrew is not transparent in how it deals with branch name changes, and we don't want users to have to run `brew tap --repair`.  Therefore we re-introduced the `master` branch here as non-default branch.  We do however also want to run CI on it, so re-enable that, and add a CI job pushing updates to `main` to `master` automatically.