### PR TITLE
set fetch-depth for synchronize checkout to 0

### DIFF
--- a/.github/workflows/synchronize-with-main.yml
+++ b/.github/workflows/synchronize-with-main.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@main
         with:
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          fetch-depth: 0
       - name: Push to `master`
         run: |
           git push origin HEAD:master


### PR DESCRIPTION
We need to fetch the history for at least the master branch in this repo.  Since the repo is really small (and will keep being this way), the cheapest way to do it is to just clone all branches.  Setting `fetch-depth` to 0 does exactly that.

Fixes https://github.com/pulumi/homebrew-tap/issues/30